### PR TITLE
Refactor `assertDestroyablesDestroyed` to match real implementation.

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -5,5 +5,6 @@ export {
   registerDestructor,
   unregisterDestructor,
   destroy,
-  assertDestroyablesDestroyed
+  assertDestroyablesDestroyed,
+  enableDestroyableTracking
 } from './-internal/destructors';


### PR DESCRIPTION
In order to avoid permanently leaking all destroyables in debug builds the final implementation in `@glimmer/runtime` implemented `assertDestroyablesDestroyed` to require a `enableDestroyableTracking` method to be called first (this swaps the internal tracking from a `WeakMap` to a `Map`). `enableDestroyableTracking` is expected to be called before each test that will use `assertDestroyablesDestroyed` at the end.

See implementation over in https://github.com/glimmerjs/glimmer-vm/blob/v0.55.0/packages/@glimmer/runtime/lib/destroyables.ts