### PR TITLE
Update parent / child destructor ordering to match `ember-source@3.20.0` implementation

### DIFF
--- a/addon/-internal/destructors.ts
+++ b/addon/-internal/destructors.ts
@@ -252,12 +252,11 @@ export function runDestructors(destroyable: object): void {
 
   const m = meta(destroyable);
 
-  schedule('actions', () => {
-    for (const destructor of getDestructors(destroyable))
-      destructor(destroyable);
-  });
-
   for (const child of getDestroyableChildren(destroyable)) destroy(child);
+
+  for (const destructor of getDestructors(destroyable)) {
+    schedule('actions', undefined, destructor, destroyable);
+  }
 
   schedule('destroy', () => {
     deleteMeta(destroyable);

--- a/tests/unit/destroyable-test.ts
+++ b/tests/unit/destroyable-test.ts
@@ -127,7 +127,7 @@ module('destroyable', function (_hooks) {
     assertLifecycle(assert, 'destroyed', child);
 
     assert.verifySteps(
-      ['parent-first', 'parent-second', 'child-first', 'child-second'],
+      ['child-first', 'child-second', 'parent-first', 'parent-second'],
       'Destructors were called in correct order.'
     );
 
@@ -177,12 +177,12 @@ module('destroyable', function (_hooks) {
 
       assert.verifySteps(
         [
-          'parent-willDestroy',
-          'parent-first',
-          'parent-second',
           'child-willDestroy',
           'child-first',
-          'child-second'
+          'child-second',
+          'parent-willDestroy',
+          'parent-first',
+          'parent-second'
         ],
         'Destructors were called in correct order.'
       );
@@ -232,12 +232,12 @@ module('destroyable', function (_hooks) {
 
       assert.verifySteps(
         [
-          'parent-willDestroy',
-          'parent-first',
-          'parent-second',
           'child-willDestroy',
           'child-first',
-          'child-second'
+          'child-second',
+          'parent-willDestroy',
+          'parent-first',
+          'parent-second'
         ],
         'Destructors were called in correct order.'
       );


### PR DESCRIPTION
The order that was originally implemented here in the polyfill is precisely what the RFC specifies ([see here](https://github.com/emberjs/rfcs/blob/master/text/0580-destroyables.md#destroy)):

> 1. Mark the destroyable such that isDestroying(destroyable) returns true
> 2. Schedule calling the destroyable's destructors
> 3. Call destroy() on each of the destroyable's associated children
> 4. Schedule setting destroyable such that isDestroyed(destroyable) returns true

However, when implementing we determined that the order should actually be slightly different:

1. Mark the destroyable such that isDestroying(destroyable) returns true
2. Call destroy() on each of the destroyable's associated children
3. Schedule calling the destroyable's destructors
4. Schedule setting destroyable such that isDestroyed(destroyable) returns true

This is specifically so that we can unify the destruction semantics between those of Ember.Object/CoreObject and what is done in the rendering engine:

https://github.com/glimmerjs/glimmer-vm/blob/v0.55.0/packages/@glimmer/runtime/lib/destroyables.ts#L165-L183

---

This updates the destruction ordering to match what was implemented (and released) in Ember 3.20.0+.