### PR TITLE
docs(README): remove RFC FCP warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ Polyfill for [RFC 580 "Destroyables"][rfc-580].
 
 [rfc-580]: https://github.com/emberjs/rfcs/pull/580
 
-> ⚠️The RFC is currently in Final Comment Period and hasn't been merged yet.
-> Things may still change.
-
 ## Installation
 
 ```bash


### PR DESCRIPTION
https://github.com/emberjs/rfcs/pull/580 has been merged since. There were minor changes, but this polyfill has been updated accordingly and was released as a stable v1.0.0.