### PR TITLE
Ensure interop with `ember-cli-babel` transpilation of `@ember/destroyable`

### DIFF
--- a/vendor/ember-destroyable-polyfill/register.js
+++ b/vendor/ember-destroyable-polyfill/register.js
@@ -5,6 +5,16 @@
     setTimeout(function () {
       require('ember-destroyable-polyfill/-internal/patch-meta');
       require('ember-destroyable-polyfill/-internal/patch-core-object');
+
+      var destroyables = require('ember-destroyable-polyfill');
+
+      Ember._registerDestructor = destroyables.registerDestructor;
+      Ember._unregisterDestructor = destroyables.unregisterDestructor;
+      Ember._associateDestroyableChild = destroyables.associateDestroyableChild;
+      Ember._assertDestroyablesDestroyed = destroyables.assertDestroyablesDestroyed;
+      Ember._enableDestroyableTracking = destroyables.enableDestroyableTracking;
+      Ember._isDestroying = destroyables.isDestroying;
+      Ember._isDestroyed = destroyables.isDestroyed;
     }, 0);
   }
 })();


### PR DESCRIPTION
This sets the properties that will be used when ember-cli-babel transpiles `@ember/destroyable` to the `Ember` globals based API (done by a combo of ember-rfc176-data and babel-plugin-ember-modules-api-polyfill).

This enables interop with:

* https://github.com/emberjs/ember.js/pull/19062
* https://github.com/ember-cli/ember-rfc176-data/pull/314