### PR TITLE
Ensure functionality with ember-cli-babel@7.22.0.

### DIFF
--- a/addon/-internal/meta.ts
+++ b/addon/-internal/meta.ts
@@ -181,17 +181,3 @@ export const Meta = gte('3.6.0')
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 export const meta = Ember.meta as (obj: object) => Meta;
-
-/**
- * Tears down the meta on an object so that it can be garbage collected.
- * Multiple calls will have no effect.
- *
- * @see https://github.com/emberjs/ember.js/blob/4e254b3937abf7b6221eee11ae77f3b8a9878777/packages/@ember/-internals/meta/lib/meta.ts#L660
- * @see https://github.com/emberjs/ember.js/blob/bf273deb002904d85bf2b832c8877739920d7a08/packages/ember/index.js#L334
- *
- * @param {Object} obj  the object to destroy
- * @return {void}
- */
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-export const deleteMeta = Ember.destroy as (obj: object) => void;

--- a/vendor/ember-destroyable-polyfill/register.js
+++ b/vendor/ember-destroyable-polyfill/register.js
@@ -8,6 +8,7 @@
 
       var destroyables = require('ember-destroyable-polyfill');
 
+      Ember.destroy = destroyables.destroy;
       Ember._registerDestructor = destroyables.registerDestructor;
       Ember._unregisterDestructor = destroyables.unregisterDestructor;
       Ember._associateDestroyableChild = destroyables.associateDestroyableChild;


### PR DESCRIPTION
In ember-cli-babel@7.22.0 the imports from `@ember/destroyable` are rewritten to be global accessors from `Ember.*`. And specifically, `import { destroy } from '@ember/destroyable';` is rewritten to `Ember.destroy`. This means that we need to properly handle the normal `Ember.destroy` behavior (which changes in Ember 3.16.4+ and then again in 3.20.0-beta.4+) along with our customized behavior (to run destroyables).

This ensures that `Ember.destroy` is _our_ destroy method and runs run destructors as needed.

---

This is the first part of fixing:

```
Build Error (broccoli-persistent-filter:Babel > [Babel: ember-destroyable-polyfill]) in dummy/tests/unit/destroyable-test.ts

/home/runner/work/ember-destroyable-polyfill/ember-destroyable-polyfill/dummy/tests/unit/destroyable-test.ts: @ember/destroyable does not have a destroy export
  2 | import { module, test } from 'qunit';
  3 | 
> 4 | import {
    | ^
  5 |   isDestroying,
  6 |   isDestroyed,
  7 |   associateDestroyableChild,

=================================================================================
```