### PR TITLE
Ensure the local version is used.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
     // Add options here
+    trees: {
+      vendor: null,
+    },
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"
   },
+  "resolutions": {
+    "**/ember-destroyable-polyfill": "link:./"
+  },
   "dependencies": {
     "ember-cli-babel": "^7.22.1",
     "ember-cli-version-checker": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5028,13 +5028,12 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-co
     semver "^5.4.1"
 
 ember-destroyable-polyfill@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.1.tgz#391cd95a99debaf24148ce953054008d00f151a6"
-  integrity sha512-hyK+/GPWOIxM1vxnlVMknNl9E5CAFVbcxi8zPiM0vCRwHiFS8Wuj7PfthZ1/OFitNNv7ITTeU8hxqvOZVsrbnQ==
-  dependencies:
-    ember-cli-babel "^7.22.1"
-    ember-cli-version-checker "^5.1.1"
-    ember-compatibility-helpers "^1.2.1"
+  version "0.0.0"
+  uid ""
+
+"ember-destroyable-polyfill@link:./":
+  version "0.0.0"
+  uid ""
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
We depend on `ember-modifier` which then depends on us, this change ensures that `ember-modifier`'s version of the polyfill **is** the one being developed locally. Prior to this change, no changes in the `vendor/` files here locally would have an affect.