### PR TITLE
Avoid errors when `super.init` is called multiple times.

### DIFF
--- a/tests/unit/destroyable-test.js
+++ b/tests/unit/destroyable-test.js
@@ -180,6 +180,41 @@ module('destroyable', function () {
       assertDestroyablesDestroyed();
     });
 
+    test('calling `.init` multiple times does not error', function (assert) {
+      enableDestroyableTracking();
+
+      const thing = CoreObject.extend({
+        toString() {
+          return 'thing';
+        },
+        willDestroy() {
+          assert.step('thing-willDestroy');
+        },
+      }).create();
+
+      // this is horrible, but we cannot actually guarantee `init` is only called once
+      thing.init();
+      thing.init();
+      thing.init();
+
+      registerTestDestructors(assert, 'thing', thing);
+
+      assertLifecycle(assert, 'initialized', thing);
+
+      run(() => {
+        destroy(thing);
+
+        assertLifecycle(assert, 'destroying', thing);
+      });
+
+      assert.verifySteps(
+        ['thing-willDestroy', 'thing-first', 'thing-second'],
+        'Destructors were called in correct order.'
+      );
+
+      assertDestroyablesDestroyed();
+    });
+
     test('destroy hook', function (assert) {
       assert.expect(35);
 

--- a/vendor/ember-destroyable-polyfill/index.js
+++ b/vendor/ember-destroyable-polyfill/index.js
@@ -214,8 +214,14 @@ import { gte } from 'ember-compatibility-helpers';
 
     const callWillDestroy = (instance) => instance.willDestroy();
 
+    // would prefer a WeakSet here but not available on IE11
+    const willDestroyRegistered = new WeakMap();
+
     Ember.CoreObject.prototype.init = function destroyablesPolyfill_init() {
-      registerDestructor(this, callWillDestroy);
+      if (!willDestroyRegistered.has(this)) {
+        registerDestructor(this, callWillDestroy);
+        willDestroyRegistered.set(this, true);
+      }
     };
 
     Ember.CoreObject.prototype.destroy = function destroyablesPolyfill_destroy() {


### PR DESCRIPTION
When running on Ember < 3.20 calling the super classes `init` more than once would issue an assertion:

```js
`'${destructor}' is already registered with '${destroyable}'.`
```

Normally, any case where you are actually invoking `super.init` multiple times should just be fixed in your source (it is fundamentally "bad" and is almost certainly a logic error in application code). Unfortunately, there are cases today where you _accidentally_ call the super classes `init` method. For example, when you call `this._super()` in a computed property if that property did not exist on the super class the value of the `this._super` property is whatever _happened_ to be the most recent super wrapped function that was invoked. 😱

This ensures that calling `init` multiple times does **not** error (and does not end up causing `willDestroy` to be called more than once) by only registering the destructor if needed.