### PR TITLE
fix: find `ember-source` version of project

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     this._super.included.apply(this, arguments);
     this._ensureThisImport();
 
-    const checker = new VersionChecker(this);
+    const checker = new VersionChecker(this.project);
     const emberVersion = checker.for('ember-source');
 
     if (emberVersion.lt(NATIVE_SUPPORT_VERSION)) {


### PR DESCRIPTION
Currently, the version-checking library is passed the addon itself to
find the `ember-source` version of. This is not recommended in the
package's README:

https://github.com/ember-cli/ember-cli-version-checker#should-i-use-project-or-parent

This has caused issues with locating the correct version when used
within a mono-repo that contains packages using different Ember versions.

Passing `this.project` instead ensures that the polyfill is installed based on the host app's Ember version, as it should.
