### PR TITLE
docs(README): specify upper Ember.js version bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For addons, pass the `-S` flag.
 
 ## Compatibility
 
-* Ember.js v3.4 or above
+* Ember.js v3.4 or above; completely inert for v3.22.0-alpha.1 and above
 * `ember-cli-babel` v7.22.1 or above
 * Ember CLI v2.13 or above
 * Node.js v10 or above


### PR DESCRIPTION
As per the `NATIVE_SUPPORT_VERSION` in `index.js`, this addon is inert for Ember.js `^3.22.0-alpha.1`.

https://github.com/ember-polyfills/ember-destroyable-polyfill/blob/218de5ce9754794a95956a4214cab192e5efed68/index.js#L3-L25